### PR TITLE
Do not send response from the dramatiq task

### DIFF
--- a/django_dramatiq_email/backends.py
+++ b/django_dramatiq_email/backends.py
@@ -5,14 +5,11 @@ from django_dramatiq_email.utils import email_to_dict
 
 
 class DramatiqEmailBackend(BaseEmailBackend):
-    def __init__(self, fail_silently=False, **kwargs):
+    def __init__(self, fail_silently: bool = False, **kwargs) -> None:
         super().__init__(fail_silently)
         self.init_kwargs = kwargs
 
-    def send_messages(self, email_messages):
-        result_tasks = []
+    def send_messages(self, email_messages) -> int:
         for message in email_messages:
-            result_tasks.append(
-                send_email.send(email_to_dict(message), self.init_kwargs)
-            )
-        return result_tasks
+            send_email.send(email_to_dict(message), self.init_kwargs)
+        return len(email_messages)

--- a/django_dramatiq_email/tasks.py
+++ b/django_dramatiq_email/tasks.py
@@ -6,8 +6,8 @@ import logging
 import dramatiq
 from django.conf import settings
 from django.core.mail import get_connection
-
 from django.core.mail.backends.base import BaseEmailBackend
+
 from django_dramatiq_email.utils import dict_to_email, email_to_dict
 
 TASK_CONFIG = {

--- a/django_dramatiq_email/tasks.py
+++ b/django_dramatiq_email/tasks.py
@@ -7,6 +7,7 @@ import dramatiq
 from django.conf import settings
 from django.core.mail import get_connection
 
+from django.core.mail.backends.base import BaseEmailBackend
 from django_dramatiq_email.utils import dict_to_email, email_to_dict
 
 TASK_CONFIG = {
@@ -19,17 +20,17 @@ if hasattr(settings, "DRAMATIQ_EMAIL_TASK_CONFIG"):
 
 
 @dramatiq.actor(**TASK_CONFIG)
-def send_email(message, backend_kwargs=None):
+def send_email(message, backend_kwargs=None) -> None:
     message = email_to_dict(message)
     backend_kwargs = backend_kwargs or {}
+    conn: BaseEmailBackend
     conn = get_connection(backend=settings.DRAMATIQ_EMAIL_BACKEND, **backend_kwargs)
     try:
         conn.open()
     except Exception:
-        logging.exception("Cannot reach backend %s", settings.DRAMATIQ_EMAIL_BACKEND)
+        logging.exception("Cannot reach DRAMATIQ_EMAIL_BACKEND")
+        raise
 
-    sent = conn.send_messages([dict_to_email(message)])
+    conn.send_messages([dict_to_email(message)])
     logging.debug("Successfully sent email message to %r.", message["to"])
-
     conn.close()
-    return sent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-dramatiq-email"
-version = "1.3.0"
+version = "1.3.1"
 description = "A Django email backend using Dramatiq to send emails using background workers"
 authors = ["Tim Drijvers <tim@sendcloud.com>"]
 homepage = "https://github.com/sendcloud/django-dramatiq-email"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -73,14 +73,6 @@ def test_send_single_email_object_no_backend_kwargs():
     assert email_to_dict(msg) == email_to_dict(mail.outbox[0])
 
 
-def test_send_single_email_object_response():
-    """It should return the number of messages sent, 1 here."""
-    msg = mail.EmailMessage()
-    messages_sent = tasks.send_email(msg)
-    assert messages_sent == 1
-    assert len(mail.outbox) == 1
-
-
 def test_send_single_email_dict():
     """It should accept and send a single EmailMessage dict."""
     msg = mail.EmailMessage()
@@ -189,7 +181,7 @@ def test_sending_email(stub_broker, stub_worker):
     )
     stub_broker.join("django_email")
     stub_worker.join()
-    assert len(tasks) == 1
+    assert tasks == 1
     assert len(mail.outbox) == 1
     assert mail.outbox[0].subject == "test"
 
@@ -206,7 +198,7 @@ def test_sending_html_email(stub_broker, stub_worker, mixed_subtype):
     stub_broker.join("django_email")
     stub_worker.join()
 
-    assert len(tasks) == 1
+    assert tasks == 1
     assert len(mail.outbox) == 1
     assert mail.outbox[0].subject == "test"
     assert len(mail.outbox[0].alternatives) == 1
@@ -222,7 +214,7 @@ def test_sending_mail_with_text_attachment(stub_broker, stub_worker):
     stub_broker.join("django_email")
     stub_worker.join()
 
-    assert len(tasks) == 1
+    assert tasks == 1
     assert len(mail.outbox) == 1
     assert mail.outbox[0].subject == "test"
     assert mail.outbox[0].content_subtype == "plain"
@@ -240,7 +232,7 @@ def test_sending_html_only_email(stub_broker, stub_worker):
     stub_broker.join("django_email")
     stub_worker.join()
 
-    assert len(tasks) == 1
+    assert tasks == 1
     assert len(mail.outbox) == 1
     assert mail.outbox[0].subject == "test"
     assert mail.outbox[0].content_subtype == "html"
@@ -255,6 +247,6 @@ def test_sending_mass_email(stub_broker, stub_worker):
     stub_broker.join("django_email")
     stub_worker.join()
 
-    assert len(tasks) == 2
+    assert tasks == 2
     assert len(mail.outbox) == 2
     assert {mail.outbox[i].subject for i in range(2)} == {"mass 1", "mass 2"}


### PR DESCRIPTION
## Problem

The `Actor.send` method triggers the task asynchronously and hence returns a promise instead of the actual task result. This promise is never awaited, and dramatiq scream in the logs about it on each invocation:

> Actor 'django_dramatiq_email_send_emails' returned a value that is not None, and you haven't added the Results middleware to the broker, so the value has been discarded. Consider adding the Results middleware to your broker or piping the result into another actor.

Also, the `BaseEmailBackend.send_messages` docstring says:

> Send one or more EmailMessage objects and return the number of email messages sent.

## Solution

1. Return None from the `django_dramatiq_email_send_emails` actor.
2. Return the number of messages sent from `DramatiqEmailBackend.send_messages` instead of a list of `dramatiq.Message` instances.